### PR TITLE
Fix missing use statement for PaymentFailed event and fix syntax error in PaymentChargeBack event

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Fixed
+- major issue fixed (missing semicolon) in PaymentChargedBack event.
+- major issue fixed (missing use statement for PaymentFailed) in DispatchPaymentStatusChangeEvent.
+
+### Added
+- tests for DispatchPaymentStatusChangeEvent
+
 ## 2017-07-14
 This change substitutes the omnipay/mollie package for the official mollie/molli-api-php client.
 

--- a/src/Events/PaymentChargedBack.php
+++ b/src/Events/PaymentChargedBack.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SanderVanHooft\PayableRedirect\Events
+namespace SanderVanHooft\PayableRedirect\Events;
 
 use SanderVanHooft\PayableRedirect\Events\PaymentEvent;
 

--- a/src/Listeners/DispatchPaymentStatusChangeEvent.php
+++ b/src/Listeners/DispatchPaymentStatusChangeEvent.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use SanderVanHooft\PayableRedirect\Events\PaymentCancelled;
 use SanderVanHooft\PayableRedirect\Events\PaymentChargedBack;
 use SanderVanHooft\PayableRedirect\Events\PaymentExpired;
+use SanderVanHooft\PayableRedirect\Events\PaymentFailed;
 use SanderVanHooft\PayableRedirect\Events\PaymentOpened;
 use SanderVanHooft\PayableRedirect\Events\PaymentPaid;
 use SanderVanHooft\PayableRedirect\Events\PaymentPaidOut;

--- a/tests/Feature/CanHandleChangeEventTest.php
+++ b/tests/Feature/CanHandleChangeEventTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SanderVanHooft\PayableRedirect\Feature;
+
+use Illuminate\Support\Facades\Event;
+use SanderVanHooft\PayableRedirect\AbstractTestCase;
+use SanderVanHooft\PayableRedirect\Events\PaymentCancelled;
+use SanderVanHooft\PayableRedirect\Events\PaymentChargedBack;
+use SanderVanHooft\PayableRedirect\Events\PaymentExpired;
+use SanderVanHooft\PayableRedirect\Events\PaymentFailed;
+use SanderVanHooft\PayableRedirect\Events\PaymentOpened;
+use SanderVanHooft\PayableRedirect\Events\PaymentPaid;
+use SanderVanHooft\PayableRedirect\Events\PaymentPaidOut;
+use SanderVanHooft\PayableRedirect\Events\PaymentPending;
+use SanderVanHooft\PayableRedirect\Events\PaymentRefunded;
+use SanderVanHooft\PayableRedirect\Events\PaymentUpdated;
+use SanderVanHooft\PayableRedirect\Listeners\DispatchPaymentStatusChangeEvent;
+use SanderVanHooft\PayableRedirect\Payment;
+
+class CanHandleChangeEventTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider eventProvider
+     * @test
+     */
+    public function canHandleFailedEvent($status, $eventName)
+    {
+        Event::fake();
+
+        $listener = new DispatchPaymentStatusChangeEvent();
+
+        $payment = new Payment();
+
+        $payment->status = $status;
+
+        $event = new PaymentUpdated($payment);
+
+        $listener->handle($event);
+
+        Event::assertDispatched($eventName);
+    }
+
+    public function eventProvider()
+    {
+        return [
+            ['open', PaymentOpened::class],
+            ['cancelled', PaymentCancelled::class],
+            ['pending', PaymentPending::class],
+            ['expired', PaymentExpired::class],
+            ['failed', PaymentFailed::class],
+            ['paid', PaymentPaid::class],
+            ['paidout', PaymentPaidOut::class],
+            ['refunded', PaymentRefunded::class],
+            ['charged_back', PaymentChargedBack::class]
+        ];
+    }
+}


### PR DESCRIPTION
## Description

The _DispatchPaymentStatusChangeEvent_ class used the _PaymentFailed_ event from the wrong namespace.

## Motivation and context

This is required to use the __DispatchPaymentStatusChangeEvent_ to listen to specific events in a laravel application.

## How has this been tested?

I've added the `CanHandleChangeEventTest.php` file which includes a dataprovider to test all cases which the _CanHandleChangeEventTest_ class should handle.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
